### PR TITLE
Battery module fix

### DIFF
--- a/bar.sh
+++ b/bar.sh
@@ -15,7 +15,6 @@
 #     You should have received a copy of the GNU General Public License
 #     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
 MODULES_DIR="/usr/share/dwmbar/modules/"
 
 OUTPUT_CACHE="/home/$USER/.config/dwmbar/.cache/"
@@ -67,8 +66,9 @@ run()
 {
     get_internet
 	for module in $MODULES; do
-		if [[ $INTERNET -eq 0 ]]; then
-			run_module $module
+		pgrep $module &> /dev/null
+		if [[ $INTERNET -eq 0 ]] && [[ $? -eq 1 ]]; then
+			run_module $module &
 		else
 			[[ $ONLINE_MODULES != *"$module"* ]] && run_module $module
 		fi

--- a/bar.sh
+++ b/bar.sh
@@ -40,8 +40,8 @@ get_bar()
 {
 	for module in $MODULES; do
 		if [[ $INTERNET -eq 0 ]] || [[ $ONLINE_MODULES != *"$module"* ]];then
-			module_out=$(cat $OUTPUT_CACHE$module | sed 's/\.$//g')
-			bar=$bar$module_out
+			module_out="$(cat $OUTPUT_CACHE$module | sed 's/\.$//g')"
+			bar="$bar$module_out"
 		fi
 	done
 	# Uncomment to remove last separator
@@ -59,7 +59,7 @@ run_module()
 	fi
 
 	[[ ! "$out" = "" ]] && [[ ! "$module" = "NULL" ]] && out="$out$SEPARATOR."
-	echo $out > "$OUTPUT_CACHE$module"
+	echo "$out" > "$OUTPUT_CACHE$module"
 }
 
 run()

--- a/modules/battery
+++ b/modules/battery
@@ -2,12 +2,12 @@
 
 # Prints out battery percentage
 
-CHARGING_ICON=''
-WARNING_ICON=''
-BATTERY_FULL_ICON=''
-BATTERY_2_ICON=''
-BATTERY_3_ICON=''
-BATTERY_4_ICON=''
+CHARGING_ICON=' '
+WARNING_ICON=' '
+BATTERY_FULL_ICON=' '
+BATTERY_2_ICON=' '
+BATTERY_3_ICON=' '
+BATTERY_4_ICON=' '
 
 FULL_AT=98
 
@@ -37,7 +37,7 @@ get_battery()
 			BAT_ICON=$BATTERY_2_ICON
 		fi
 	fi
-	echo "$ICON $BAT_ICON $capacity%"
+	echo "$ICON $BAT_ICON  $capacity%"
 }
 
 get_battery

--- a/modules/battery
+++ b/modules/battery
@@ -9,36 +9,35 @@ BATTERY_2_ICON=''
 BATTERY_3_ICON=''
 BATTERY_4_ICON=''
 
+FULL_AT=98
+
+BAT_ICON=""
+ICON=""
+
 get_battery()
 {
-    if [ -d /sys/class/power_supply/BAT? ]; then
-        ac_adapter=$(cat /sys/class/power_supply/BAT?/status)
-        if [ "$ac_adapter" == "Charging" ]; then
-            echo "$CHARGING_ICON"
-        fi
+	# The vast majority of people only use one battery.
 
-        # Will show all batteries with approximate icon for remaining power.
-        for x in /sys/class/power_supply/BAT?/capacity;
-        do
-            case "$(cat $x)" in
-                100)            echo "$BATTERY_FULL_ICON"            ;;
-                9[0-9])         echo "$BATTERY_FULL_ICON $(cat $x)%" ;;
-                8[0-9]|7[0-9])  echo "$BATTERY_2_ICON $(cat $x)%" ;;
-                6[0-9]|5[0-9])  echo "$BATTERY_3_ICON $(cat $x)%" ;;
-                4[0-9]|3[0-9])  echo "$BATTERY_4_ICON $(cat $x)%" ;;
-                2[0-9]|1[0-9])  if [ "$ac_adapter" == "Charging" ]; then
-                                    echo "$BATTERY_4_ICON $(cat $x)%"
-                                else
-                                    echo "$WARNING_ICON  $BATTERY_4_ICON $(cat $x)%"
-                                fi ;;
-                [0-9])          if [ "$ac_adapter" == "Charging" ]; then
-                                    echo "$BATTERY_4_ICON $(cat $x)%"
-                                else
-                                    echo "$WARNING_ICON  $BATTERY_4_ICON $(cat $x)%"
-                                fi ;;
-                esac
-        done
-    fi
+	if [ -d /sys/class/power_supply/BAT0 ]; then
+		capacity=$(cat /sys/class/power_supply/BAT0/capacity)
+		charging=$(cat /sys/class/power_supply/BAT0/status)
+		if [[ "$charging" == "Charging" ]]; then
+			ICON="$CHARGING_ICON"
+		elif [[ $capacity -le 25 ]]; then
+			ICON="$WARNING_ICON"
+		fi
+
+		if [[ $capacity -ge $FULL_AT ]]; then
+			BAT_ICON=$BATTERY_FULL_ICON
+		elif [[ $capacity -le 25 ]]; then
+			BAT_ICON=$BATTERY_4_ICON
+		elif [[ $capacity -le 50 ]]; then
+			BAT_ICON=$BATTERY_3_ICON
+		elif [[ $capacity -le $FULL_AT ]]; then
+			BAT_ICON=$BATTERY_2_ICON
+		fi
+	fi
+	echo "$ICON $BAT_ICON $capacity%"
 }
 
 get_battery


### PR DESCRIPTION
Fixes a problem in bar.sh where additional whitespace will be truncated. Means that text after certain icons would be inside the icon itself.